### PR TITLE
Build hardening: lazy anon Supabase client, header visibility control…

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ To enable the CI smoke job (`.github/workflows/ci-smoke-and-env-safety.yml`) you
 - `SMOKE_TEST_TOKEN` — short-lived token that the staging server recognizes for simulate verify (keep secret)
 
 The CI job will run env-safety, build, and smoke test after changes are pushed to `main`.
-<<<<<<< HEAD
-=======
 
 ## Marketing Tracking (Meta Pixel & Conversions API)
 
@@ -82,4 +80,3 @@ To keep Pixel-only (no server calls):
 - Leave `NEXT_PUBLIC_ENABLE_CAPI` unset (or not equal to `true`). The server Purchase event will be suppressed.
 
 If you later add CAPI, no code change is required—just set the envs and redeploy.
->>>>>>> my-feature-branch

--- a/src/app/api/customers/orders/route.ts
+++ b/src/app/api/customers/orders/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/supabaseClient';
+import { getAnonSupabase } from '@/supabaseClient';
 import { Order } from '@/lib/types';
 
 // GET orders for a specific customer
@@ -12,6 +12,10 @@ export async function GET(req: NextRequest) {
     const customerId = url.searchParams.get('customerId');
     if (!customerId) {
       return NextResponse.json({ success: false, error: 'customerId is required' }, { status: 400 });
+    }
+    const supabase = getAnonSupabase();
+    if (!supabase) {
+      return NextResponse.json({ success: false, error: 'Supabase anon env vars not configured' }, { status: 503 });
     }
     const { data: orders, error } = await supabase
       .from('orders')

--- a/src/app/api/test-supabase/route.ts
+++ b/src/app/api/test-supabase/route.ts
@@ -1,9 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/supabaseClient';
+import { getAnonSupabase } from '@/supabaseClient';
 
 export async function GET(req: NextRequest) {
   try {
     // Try a simple query to test Supabase connectivity
+    const supabase = getAnonSupabase();
+    if (!supabase) {
+      return NextResponse.json({ success: false, error: 'Supabase anon env vars not configured' }, { status: 503 });
+    }
     const { data, error } = await supabase.from('orders').select('*').limit(1);
     if (error) {
       return NextResponse.json({ success: false, error: error.message, details: error }, { status: 500 });

--- a/src/app/components/ConditionalHeader.tsx
+++ b/src/app/components/ConditionalHeader.tsx
@@ -10,7 +10,7 @@ export default function ConditionalHeader() {
   const pathname = usePathname();
   const path = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
   // hide on checkout and the previously hidden pages
-  const hidePaths = ['/join', '/order-quantum-machine', '/quantum', '/shop/checkout', '/signin'];
+  const hidePaths = ['/join', '/order-quantum-machine', '/shop/checkout', '/signin', '/quantum'];
   if (hidePaths.includes(path) || hidePaths.some(p => path.startsWith(p + '/'))) {
     return null;
   }

--- a/src/app/components/SiteHeader.tsx
+++ b/src/app/components/SiteHeader.tsx
@@ -41,7 +41,7 @@ export default function SiteHeader() {
   useEffect(() => {
     try {
       const path = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
-    const hidePaths = ['/join', '/order-quantum-machine', '/quantum', '/shop/checkout', '/admin'];
+  const hidePaths = ['/join', '/order-quantum-machine', '/shop/checkout', '/admin', '/quantum'];
       if (hidePaths.includes(path) || hidePaths.some(p => path.startsWith(p + '/'))) {
         setHidden(true);
       } else {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { CartProvider } from "./shop/CartContext";
 import MetaPixelProvider from "./MetaPixelProvider";
 import AttributionCapture from "./modules/AttributionCapture";
 import GlobalDisclaimer from "./components/GlobalDisclaimer";
+const ConditionalHeader = dynamic(() => import('./components/ConditionalHeader'), { ssr: false });
 
 // const geistSans = localFont({
 //   src: "./fonts/GeistVF.woff",
@@ -97,6 +98,7 @@ export default function RootLayout({
             <CartProvider>
               <MetaPixelProvider />
               <AttributionCapture />
+              <ConditionalHeader />
               {children}
               <GlobalDisclaimer />
             </CartProvider>

--- a/src/lib/attributionServer.ts
+++ b/src/lib/attributionServer.ts
@@ -1,0 +1,32 @@
+// Server-side attribution helpers for tests & APIs.
+// Mirrors logic used inline in funnel create for extracting attribution cookies.
+
+export interface ParsedAttributionCookies {
+  first: any | null;
+  last: any | null;
+  clicks: Record<string,string> | null;
+}
+
+function parseJSON<T>(raw: string | null): T | null { if (!raw) return null; try { return JSON.parse(raw) as T; } catch { return null; } }
+
+export function extractCookieMap(cookieHeader: string): Record<string,string> {
+  const out: Record<string,string> = {};
+  if (!cookieHeader) return out;
+  cookieHeader.split(/;\s*/).forEach(pair => {
+    const idx = pair.indexOf('=');
+    if (idx === -1) return;
+    const k = pair.slice(0, idx);
+    const v = pair.slice(idx + 1);
+    if (!out[k]) out[k] = decodeURIComponent(v);
+  });
+  return out;
+}
+
+export function parseAttributionFromHeader(cookieHeader: string): ParsedAttributionCookies {
+  const map = extractCookieMap(cookieHeader);
+  return {
+    first: parseJSON(map['ca_utm_first'] || null),
+    last: parseJSON(map['ca_utm_last'] || null),
+    clicks: parseJSON<Record<string,string>>(map['ca_click_ids'] || null)
+  };
+}

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -3,7 +3,7 @@
 import NextAuth from "next-auth";
 import fs from 'fs';
 import CredentialsProvider from "next-auth/providers/credentials";
-import { supabase } from "@/supabaseClient";
+import { getAnonSupabase } from "@/supabaseClient";
 
 export const authOptions = {
   providers: [
@@ -15,6 +15,11 @@ export const authOptions = {
       },
       async authorize(credentials) {
         // Use Supabase Auth for authentication and check for admin role
+        const supabase = getAnonSupabase();
+        if (!supabase) {
+          // Env not configured; deny auth gracefully
+          return null;
+        }
         const { data, error } = await supabase.auth.signInWithPassword({
           email: credentials?.email || "",
           password: credentials?.password || ""

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,32 +1,30 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+let cached: any = null;
 
-// Prefer the platform global fetch (Node 18+, deno, or browser) so
-// @supabase/supabase-js doesn't bundle its node-fetch variant which
-// pulls `whatwg-url` -> `punycode` and triggers DEP0040.
-// If globalThis.fetch is not available (older Node), fall back to undici.
-let platformFetch: typeof fetch | undefined = (globalThis as any).fetch;
-try {
-	if (!platformFetch) {
-		// lazy require to avoid importing undici in environments that already have fetch
-		// use eval('require') to prevent webpack from statically bundling node-only modules
-		try {
-			// eslint-disable-next-line no-eval
-			const req = eval('require');
-			const { fetch: undiciFetch } = req('undici');
-			platformFetch = undiciFetch;
-		} catch (e) {
-			// undici not available or we're in a bundler context — leave undefined
-		}
-	}
-} catch (e) {
-	// If undici isn't installed and fetch isn't available, leave undefined;
-	// supabase-js will fall back to its default which may bring node-fetch.
+function resolveFetch() {
+  let platformFetch: typeof fetch | undefined = (globalThis as any).fetch;
+  try {
+    if (!platformFetch) {
+      // eslint-disable-next-line no-eval
+      const req = eval('require');
+      const { fetch: undiciFetch } = req('undici');
+      platformFetch = undiciFetch;
+    }
+  } catch {}
+  return platformFetch;
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-	// @ts-ignore - createClient accepts a `fetch` option in recent versions.
-	fetch: platformFetch,
-});
+export function getAnonSupabase() {
+  if (cached) return cached;
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) return null;
+  // If newer supabase-js supports custom fetch, we could pass it; omit for build safety.
+  cached = createClient(supabaseUrl, supabaseAnonKey);
+  return cached;
+}
+
+// Backwards export (may be null) for existing imports
+export const supabase = getAnonSupabase();
+export default supabase;


### PR DESCRIPTION
### Summary
Hardens build against missing public Supabase env vars and restores global header with controlled route hiding.

### Key Changes
- Lazy, null-safe anon Supabase client (`supabaseClient.ts`) to prevent build-time crash.
- Safer `resend-audit` route: falls back to anon or shim.
- Added routes using getter pattern (`test-supabase`, `customers/orders`, NextAuth authorize).
- Reintroduced global header via `ConditionalHeader`; updated hide rules (e.g. hide /quantum).
- Added server attribution helper `attributionServer.ts`.
- Minor README updates.

### Tracking & Attribution (Previously Landed On main, Still Working)
- Meta Pixel + optional Conversions API w/ deduped event_id.
- Purchase server event from Paystack webhook.
- UTM & click ID first/last touch cookies; advanced matching fields.
- Consent gating (cookie_consent.analytics flag).
- Attribution debug admin endpoint.

### Safety / Ops
- No secrets committed (.env.local ignored).
- Fallback behavior returns 503 instead of throwing when anon env vars absent.

### Validation Checklist (Completed Locally)
- Pixel loads when consent allows; blocks when `cookie_consent={"analytics":false}`.
- Header visible on marketing pages; hidden on configured routes.
- Auth (credentials) flow works; admin flag preserved.
- Paystack initialization + webhook path unaffected.

### Post-Merge Actions
- Confirm Vercel env vars: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, NEXTAUTH_SECRET, NEXT_PUBLIC_FB_PIXEL_ID, NEXT_PUBLIC_PAYSTACK_PUBLIC_KEY, PAYSTACK_SECRET_KEY, RESEND_API_KEY, RESEND_FROM_EMAIL, ADMIN_API_KEY, NEXT_PUBLIC_BASE_URL.
- Turn `CONTACT_DEBUG` to `false` in production env if sending real emails.
